### PR TITLE
Cosmit for kid metric

### DIFF
--- a/fls/metrics/KID.py
+++ b/fls/metrics/KID.py
@@ -136,7 +136,7 @@ class KID(Metric):
 
         if self.mode == "train":
             ref_feat = sample_ref_feat(train_feat).cpu()
-        if self.mode == "test":
+        elif self.mode == "test":
             ref_feat = sample_ref_feat(test_feat).cpu()
         else:
             raise ValueError("reference_feat must be one of 'train' or 'test'")


### PR DESCRIPTION
I think `KID(mode="train"` was failing because of a missing `elif`